### PR TITLE
PoseTracker.get_memory() fix

### DIFF
--- a/src/loc_ndf/utils/registration.py
+++ b/src/loc_ndf/utils/registration.py
@@ -171,13 +171,14 @@ class PoseTracker:
 
     def get_memory(self):
         param_size = 0
+        buffer_size = 0
 
         for model in self.models:
             for param in model.parameters():
                 param_size += param.nelement() * param.element_size()
-            buffer_size = 0
             for buffer in model.buffers():
                 buffer_size += buffer.nelement() * buffer.element_size()
+
         size_all_mb = (param_size + buffer_size) / 1024**2
         return size_all_mb
 ##############################################################################


### PR DESCRIPTION
Hi @louis-wiesmann ,

I think the variable "buffer_size" must be placed before the for loop. Or did I miss something? This PR should fix it.

best regards
Alex